### PR TITLE
BE-331 Display health status of peers and orderers- Backend

### DIFF
--- a/app/platform/fabric/gateway/FabricGateway.ts
+++ b/app/platform/fabric/gateway/FabricGateway.ts
@@ -488,4 +488,17 @@ export class FabricGateway {
 
 		return null;
 	}
+
+	async getActiveOrderersList(channel_name) {
+		const network = await this.gateway.getNetwork(channel_name);
+		let orderers = [];
+		for (let [orderer, ordererMetadata] of network.discoveryService.channel.committers) {
+			let ordererAtrributes = {
+				name: orderer,
+				connected: ordererMetadata.connected
+			}
+			orderers.push(ordererAtrributes);
+		}
+		return orderers;
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
This feature enables the explorer to indicate the health status of peers and orderers that are online or offline.
As of now the explorer is not showing the status of peers/orderers that are part of HLF-Network. With this new feature enablement, we could display the health status of peers/orderers in the explorer dashboard.
#### Which issue(s) this PR fixes:
Fixes #331
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:
This functionality can be tested using the reqURL:
`http://<host>:<port>/api/peersStatus/:channel`
_Note_ : As part of testing, please pass bearer token for authorization
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
