### PR TITLE
BE 334 fetch data by block number, block range and transaction id - Backend

### DIFF
--- a/app/persistence/fabric/CRUDService.ts
+++ b/app/persistence/fabric/CRUDService.ts
@@ -475,6 +475,30 @@ export class CRUDService {
 		}
 	}
 	// Orderer BE-303
+
+	/**
+	 *
+	 * Returns the block by block number.
+	 *
+	 * @param {*} channel_genesis_hash
+	 * @param {*} blockNo
+	 * @returns
+	 * @memberof CRUDService
+	 */
+	async getBlockByBlocknum(network_name:any, channel_genesis_hash:any, blockNo:any) {
+		const sqlBlockTxList = `select a.* from  (
+				select (select c.name from channel c where c.channel_genesis_hash =$1 and c.network_name = $2) 
+					as channelname, blocks.blocknum,blocks.txcount ,blocks.datahash ,blocks.blockhash ,blocks.prehash,blocks.createdt, blocks.blksize, (
+				  SELECT  array_agg(txhash) as txhash FROM transactions where blockid = $3 and 
+				   channel_genesis_hash = $1 and network_name = $2) from blocks where
+				   blocks.channel_genesis_hash =$1 and blocks.network_name = $2 and blocknum = $3)  a where  a.txhash IS NOT NULL`;
+
+		const row: any = await this.sql.getRowsBySQlCase(
+			sqlBlockTxList,
+			[channel_genesis_hash, network_name, blockNo]);
+		return row;
+	}
+
 }
 
 /**

--- a/app/platform/fabric/gateway/FabricGateway.ts
+++ b/app/platform/fabric/gateway/FabricGateway.ts
@@ -501,4 +501,26 @@ export class FabricGateway {
 		}
 		return orderers;
 	}
+
+	async queryTransaction(channelName:string, txnId:string) {
+		try {
+			const network = await this.gateway.getNetwork(this.defaultChannelName);
+			// Get the contract from the network.
+			const contract = network.getContract('qscc');
+			const resultByte = await contract.evaluateTransaction(
+				'GetTransactionByID',
+				channelName,
+				txnId
+			);
+			const resultJson = BlockDecoder.decodeTransaction(resultByte);
+			logger.debug('queryTransaction', resultJson);
+			return resultJson;
+		} catch (error) {
+			logger.error(
+				`Failed to get transaction ${txnId} from channel ${channelName} : `,
+				error
+			);
+			return null;
+		}
+	}
 }

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -758,7 +758,7 @@ export class SyncServices {
 	}
 }
 // Transaction validation code
-function convertValidationCode(code) {
+export function convertValidationCode(code) {
 	if (typeof code === 'string') {
 		return code;
 	}
@@ -766,7 +766,7 @@ function convertValidationCode(code) {
 }
 
 // Calculate data size of json object
-function jsonObjSize(json) {
+export function jsonObjSize(json) {
 	let bytes = 0;
 
 	function sizeOf(obj) {

--- a/app/rest/platformroutes.ts
+++ b/app/rest/platformroutes.ts
@@ -180,4 +180,71 @@ export async function platformroutes(
 			});
 		});
 	});
+
+	/**
+	 * *
+	 * Block by block number
+	 * GET /fetchDataByBlockNo
+	 * curl -i 'http://<host>:<port>/fetchDataByBlockNo/<channel_genesis_hash>/<blockNo>'
+	 */
+	router.get('/fetchDataByBlockNo/:channel_genesis_hash/:blockNo', (req, res) => {
+		const blockNo = parseInt(req.params.blockNo);
+		const channel_genesis_hash = req.params.channel_genesis_hash;
+		proxy.fetchDataByBlockNo(req.network, channel_genesis_hash, blockNo).then((data: any) => {
+			if (data != "response_payloads is null") {
+				res.send({ status: 200, data: data });
+			}
+			else{
+				res.send({ status: 404, data: "Block not found" });
+			}
+		});
+	});
+
+	/**
+	 * *
+	 * Blocks by block range
+	 * GET /fetchDataByBlockRange
+	 * curl -i 'http://<host>:<port>/fetchDataByBlockRange/<channel_genesis_hash>/<startBlockNo>/<endBlockNo>'
+	 */	
+	router.get('/fetchDataByBlockRange/:channel_genesis_hash/:startBlockNo/:endBlockNo', (req, res) => {
+		const startBlockNo = parseInt(req.params.startBlockNo);
+		const endBlockNo = parseInt(req.params.endBlockNo);
+		const channel_genesis_hash = req.params.channel_genesis_hash;
+		if (startBlockNo < endBlockNo) {
+			proxy.fetchDataByBlockRange(req.network, channel_genesis_hash, startBlockNo, endBlockNo).then((data: any) => {
+				if (data != "response_payloads is null") {
+					res.send({ status: 200, data: data });
+				}
+				else{
+					res.send({ status: 404, data: "Block(s) not found" });
+				}
+			});
+		}
+		else {
+			return requtil.invalidRequest(req, res);
+		}
+
+	});
+
+
+	/**
+	 * *
+	 * Transaction by txn id
+	 * GET /fetchDataByTxnId
+	 * curl -i 'http://<host>:<port>/fetchDataByTxnId/<channel_genesis_hash>/<txnId>'
+	 */
+	router.get('/fetchDataByTxnId/:channel_genesis_hash/:txnId', (req, res) => {
+		const txnId = req.params.txnId;
+		const channel_genesis_hash = req.params.channel_genesis_hash;
+		proxy.fetchDataByTxnId(req.network, channel_genesis_hash, txnId).then((data: any) => {
+			if (data != null) {
+				res.send({ status: 200, data: data });
+			}
+			else{
+				res.send({ status: 404, data: "Transaction not found" });
+			}
+		});
+	});
+
+
 } // End platformroutes()


### PR DESCRIPTION
Signed-off-by: Anusha <anu.vp.nair@gmail.com>

<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
This functionality enables the explorer to retrieve data using block id, block range (for example, blocks 1 to 10), and transaction data by giving the transaction id .Using these inputs, matching data are pulled in accordance with the user's search selection. First it will check whether the data is available in the PostgreSQL, if it is there it will fetch from there, otherwise it will fetch from blockchain.

With this new feature, data is fetched from the blockchain if it is not available in PostgreSQL using the block number, block number range, or transaction id.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #334 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
 NONE
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```
http://<host>:<port>/api/fetchDataByBlockNo/:channel_genesis_hash/:blockNo
http://<host>:<port>/api/fetchDataByBlockRange/:channel_genesis_hash/:startBlockNo/:endBlockNo
http://<host>:<port>/api/fetchDataByTxnId/:channel_genesis_hash/:txnId
_Note_ : As part of testing, please pass bearer token for authorization
```
