### PR TITLE
BE-340 Display health status of peers and orderers - FrontEnd

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,9 +4,12 @@
 	"private": true,
 	"license": "Apache-2.0",
 	"dependencies": {
+		"@emotion/react": "^11.10.5",
+		"@emotion/styled": "^11.10.5",
 		"@khanacademy/react-multi-select": "^0.2.8",
 		"@material-ui/core": "^4.11.3",
 		"@material-ui/icons": "^4.11.2",
+		"@mui/material": "^5.11.3",
 		"ajv": "^6.2.0",
 		"aphrodite": "^1.2.5",
 		"bootstrap": "^4.0.0",

--- a/client/src/components/Lists/PeersHealth.js
+++ b/client/src/components/Lists/PeersHealth.js
@@ -6,40 +6,87 @@ import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import ReactTable from '../Styled/Table';
 import { peerStatusType } from '../types';
+import Tooltip from "@mui/material/Tooltip";
+import styled from "@emotion/styled";
 
 /* eslint-disable */
 
 const styles = theme => ({
 	table: {
-		height: 335,
-		overflowY: 'scroll'
+	  height: 335,
+	  overflowY: "scroll"
 	},
 	center: {
-		textAlign: 'left'
+	  textAlign: "left"
+	},
+	circle: {
+	  width: "20px",
+	  height: "20px",
+	  display: "inline-block",
+	  borderRadius: "50%"
+	},
+	down: {
+	  backgroundColor: "red"
+	},
+	up: {
+	  backgroundColor: "green"
 	}
-});
+  
+  });
+
+const Status = styled.span`
+  &.blink {
+    animation: blink 1s infinite;
+  }
+  @keyframes blink {
+    0% {
+      transform: scale(1);
+      opacity: 0.1;
+    }
+    50% {
+      transform: scale(1);
+      opacity: 1;
+    }
+    100% {
+      transform: scale(1);
+      opacity: 0.1;
+    }
+  }
+`;
 
 /* eslint-enable */
 
 const PeersHealth = ({ peerStatus, classes }) => {
+	const statusTooltip = title => {
+		return (
+		  <Tooltip
+			title={
+			  title === "DOWN" ? "Offline" : title === "UP" ? "Online" : "Fetching Status"
+			}
+			placement="top"
+		  >
+			<Status
+			  className={`${classes.circle} ${
+				title === "DOWN" ? classes.down : classes.up
+			  } ${!title && "blink"}`}
+			/>
+		  </Tooltip>
+		);
+	  };
 	const columnHeaders = [
 		{
 			Header: 'Peer Name',
 			accessor: 'server_hostname',
 			filterAll: false,
 			className: classes.center
-		} /*
-    {
-      Header: 'Status',
-      accessor: 'status',
-      filterAll: false,
-      className: classes.center,
-      Cell: row => (
-        <Badge color="success">
-          {row.value}
-        </Badge>
-      ),
-    },*/
+		}, 
+		{
+			Header: "Status",
+			accessor: "status",
+			filterAll: false,
+			className: classes.center,
+			Cell: row => statusTooltip(row.value)
+		  }
 	];
 	return (
 		<div>


### PR DESCRIPTION

Signed-off-by: saksham1203 <saksham.s1203@gmail.com>

<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
This feature enables the explorer to indicate the health status of peers and orderers that are online or offline.
The status can be indicated with red being offline, green being online, green with flickering - fetching status.
As of now the explorer is not showing the status of peers/orderers that are part of HLF-Network. With this new feature enablement, we could display the health status of peers/orderers in the explorer dashboard.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #340 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
yes
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->

![peer status](https://user-images.githubusercontent.com/72246428/215970360-2f8e6a84-8846-484d-ba5b-d35f7f3851e6.png "peer status").
