### PR TITLE
purge functionality based on blockcount and time

### DIFF
--- a/app/persistence/fabric/postgreSQL/db/explorerpg.sql
+++ b/app/persistence/fabric/postgreSQL/db/explorerpg.sql
@@ -205,6 +205,26 @@ CREATE TABLE users
 );
 ALTER table users owner to :user;
 
+-- ---------------------------
+--  Table structure for `explorer audit`
+-- ----------------------------
+DROP TABLE IF EXISTS explorer_audit;
+CREATE TYPE purgeMode AS ENUM('TIME','BLOCKCOUNT');
+CREATE TABLE explorer_audit
+(
+  id SERIAL PRIMARY KEY,
+  lastupdated Timestamp DEFAULT NULL,
+  status varchar(255) DEFAULT NULL,
+  blockfrom integer DEFAULT NULL,
+  blockto integer DEFAULT NULL,
+  mode purgeMode DEFAULT NULL,
+  channel_genesis_hash character varying(256) DEFAULT NULL,
+  network_name varchar(255)
+);
+CREATE UNIQUE INDEX exp_audit_id
+ON explorer_audit (network_name,mode,channel_genesis_hash);
+ALTER table explorer_audit owner to :user;
+
 DROP TABLE IF EXISTS write_lock;
 CREATE TABLE write_lock
 (

--- a/app/platform/fabric/config.json
+++ b/app/platform/fabric/config.json
@@ -2,7 +2,10 @@
 	"network-configs": {
 		"test-network": {
 			"name": "Test Network",
-			"profile": "./connection-profile/test-network.json"
+			"profile": "./connection-profile/test-network.json",
+			"blockCount": 5,
+			"purgeMode":"NONE",
+			"daysToPurge": 7
 		}
 	},
 	"license": "Apache-2.0"

--- a/app/platform/fabric/sync/SyncService.ts
+++ b/app/platform/fabric/sync/SyncService.ts
@@ -12,9 +12,16 @@ import { explorerError } from '../../../common/ExplorerMessage';
 import * as FabricConst from '../../../platform/fabric/utils/FabricConst';
 import * as FabricUtils from '../../../platform/fabric/utils/FabricUtils';
 
+import * as path from 'path';
+import * as fs from 'fs';
+
 const logger = helper.getLogger('SyncServices');
 
 const fabric_const = FabricConst.fabric.const;
+const purge_mode = FabricConst.PurgeModes;
+const config_path = path.resolve(__dirname, '../config.json');
+const all_config = JSON.parse(fs.readFileSync(config_path, 'utf8'));
+const network_configs = all_config[fabric_const.NETWORK_CONFIGS];
 
 // Transaction validation code
 const _validation_codes = {};
@@ -361,6 +368,10 @@ export class SyncServices {
 
 		// Get channel information from ledger
 		const channelInfo = await client.fabricGateway.queryChainInfo(channel_name);
+		//Get purge configuration from config.json
+		const purgeMode = network_configs[network_id].purgeMode.toUpperCase();
+		const daysToPurge = network_configs[network_id].daysToPurge;
+		const blockCount = network_configs[network_id].blockCount;
 
 		if (!channelInfo) {
 			logger.info(`syncBlocks: Failed to retrieve channelInfo >> ${channel_name}`);
@@ -390,7 +401,20 @@ export class SyncServices {
 						result.missing_id
 					);
 					if (block) {
-						await this.processBlockEvent(client, block, noDiscovery);
+						if (this.validatePurgemode(purgeMode)) {
+							const lastBlockTo = await this.persistence.getCrudService()
+								.fetchLastBlockToFromExplorerAudit(purgeMode, channel_genesis_hash, network_id);
+							if (result.missing_id > lastBlockTo) {
+								await this.processBlockEvent(client, block, noDiscovery);
+							}
+							else {
+								logger.info(`Not saving this block to DB since we are keeping only recent data # ${result.missing_id}`);
+							}
+						}
+						else {
+							await this.processBlockEvent(client, block, noDiscovery);
+							logger.debug("Purge unsuccessful since purge inputs are not matching");
+						}
 					}
 				} catch {
 					logger.error(`Failed to process Block # ${result.missing_id}`);
@@ -398,6 +422,24 @@ export class SyncServices {
 			}
 		} else {
 			logger.debug('Missing blocks not found for %s', channel_name);
+		}
+		if (this.validatePurgemode(purgeMode)) {
+			let response: boolean;
+			switch (purgeMode) {
+				case purge_mode[0]: {
+					response = await this.persistence.
+						getCrudService().
+						deleteOldData(channel_genesis_hash, network_id, daysToPurge);
+					break;
+				}
+				case purge_mode[1]: {
+					response = await this.persistence
+						.getCrudService()
+						.deleteBlock(network_id, channel_genesis_hash, blockCount);
+					break;
+				}
+			}
+			logger.info(`Result of Purging based on ${purgeMode} :`, response);
 		}
 		const index = this.synchInProcess.indexOf(synch_key);
 		this.synchInProcess.splice(index, 1);
@@ -734,6 +776,13 @@ export class SyncServices {
 				}
 			});
 		}
+	}
+
+	validatePurgemode(purgeMode: string) {
+		if (Object.values(purge_mode).includes(purgeMode)) {
+			return true;
+		}
+		else return false;
 	}
 
 	/**

--- a/app/platform/fabric/utils/FabricConst.ts
+++ b/app/platform/fabric/utils/FabricConst.ts
@@ -18,3 +18,8 @@ export const fabric = {
 		NOTITY_TYPE_CLIENTERROR: '6'
 	}
 };
+
+export enum PurgeModes {
+	'TIME',
+	'BLOCKCOUNT'
+};


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

Now explorer database is saving each transaction that is committed on to the ledger making replica copies of ledger. When number of transactions increases there is a chance of outage of postgres database. In order to address this we would keep only the recent data in database and provide a query back mechanism to read back from the blockchain for any of the purged data.

Implementation

Based on BLOCKCOUNT
Based on TIME
We can set the purgeMode attribute in config.json file and according to the purge mode, it enables purging from database.
If it is based on blockcount (mention the number of blocks as blockCount value in config.json) ,it will retain those many blocks in the database and the rest of the records would be purged.
If it is based on time (mention the number of days as daysToPurge value in config.json) then it will keep those many days of records in the database according to the daystoPurge provided in the config file.
If the purgeMode attribute is set to "NONE", then purging won't happen and it will retain the complete data as of ledger.

All the audit records of deletion is saved to explorer_audit_table which is further used for the sync process.

Why is this needed?
Explorer creates duplicate copy of complete ledger data in postgres which can be of larger number and can lead to database storage outage.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #332 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
