### PR TITLE
Empty org is being displayed while fetching the list of orgs

### DIFF
--- a/app/persistence/fabric/MetricService.ts
+++ b/app/persistence/fabric/MetricService.ts
@@ -701,7 +701,7 @@ export class MetricService {
 	getTxByOrgs(network_name: any, channel_genesis_hash: any) {
 		const sqlPerOrg = ` select count(creator_msp_id), creator_msp_id
       from transactions
-      where channel_genesis_hash =$1 and network_name=$2
+      where Trim(creator_msp_id) > '' and channel_genesis_hash =$1 and network_name=$2
       group by  creator_msp_id`;
 
 		return this.sql.getRowsBySQlQuery(sqlPerOrg, [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
Test the Explorer compatibility with Hyperledger Fabric v2.4.7.
The functionality which fetches the list of orgs, is also fetching an empty org. This is due to the reason that the first transaction of type "config" is not associated with any creator organisation. So, while saving this transaction to the postgres, the field creator_msp_id is blank.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #372

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
