### PR TITLE
fix incorrect default password on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ $ cd blockchain-explorer/app
   * Change `fabric-path` to your fabric network disk path in the test-network.json file:
   * Provide the full disk path to the adminPrivateKey config option. It usually ends with `_sk`, for example:
     `/fabric-path/fabric-samples/test-network/organizations/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/keystore/priv_sk`
-  * `adminUser` and `adminPassword` is the credential for the user of Explorer to log in to the dashboard
+  * `exploreradmin` and `exploreradminpw` is the credential for the user of Explorer to log in to the dashboard
   * `enableAuthentication` is a flag to enable authentication using a login page. Setting to false will skip authentication.
 
 ## Run `create` database script:


### PR DESCRIPTION
currently `README.md` show default username as `adminUser` and password as `adminUserPw`

but actual default username & password is `exploreradmin` & `exploreradminpw`

<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
