### PR TITLE
BE-417 | resolve sigint bad trap and unexpected error

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -21,11 +21,11 @@ export DISCOVERY_AS_LOCALHOST=${DISCOVERY_AS_LOCALHOST:-true}
 export EXPLORER_APP_ROOT=${EXPLORER_APP_ROOT:-dist}
 export PORT=${PORT:-8080}
 
-function log_exit() {
+log_exit() {
   echo "Server stopped"
   exit
 }
-trap log_exit SIGINT EXIT
+trap log_exit INT EXIT
 echo "Server running..."
 
 node ${EXPLORER_APP_ROOT}/main.js name - hyperledger-explorer


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
On starting the explorer, we are getting the following error in terminal:
`./start.sh: 24: Syntax error: "(" unexpected ERROR: "app-start" exited with 2.`
On resolving the above issue, the terminal shows:
`trap: SIGINT: bad trap Server running...`
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #417 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NONE
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
