### PR TITLE
updated docker compse files with ghcr images

### DIFF
--- a/app/platform/fabric/e2e-test/docker-compose.yaml
+++ b/app/platform/fabric/e2e-test/docker-compose.yaml
@@ -16,7 +16,7 @@ networks:
 services:
 
   explorerdb.mynetwork.com:
-    image: hyperledger/explorer-db:latest
+    image: ghcr.io/hyperledger-labs/explorer-db:latest
     container_name: explorerdb.mynetwork.com
     hostname: explorerdb.mynetwork.com
     environment:
@@ -36,7 +36,7 @@ services:
       - mynetwork.com
 
   explorer.mynetwork.com:
-    image: hyperledger/explorer:latest
+    image: ghcr.io/hyperledger-labs/explorer:latest
     container_name: explorer.mynetwork.com
     hostname: explorer.mynetwork.com
     environment:

--- a/client/e2e-test/docker-compose-explorer.yaml
+++ b/client/e2e-test/docker-compose-explorer.yaml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   explorerdb.mynetwork.com:
-    image: hyperledger/explorer-db:latest
+    image: ghcr.io/hyperledger-labs/explorer-db:latest
     network_mode: "host"
     container_name: explorerdb.mynetwork.com
     hostname: explorerdb.mynetwork.com

--- a/docker-compose-testdb.yaml
+++ b/docker-compose-testdb.yaml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   explorerdb.mynetwork.com:
-    image: hyperledger/explorer-db:latest
+    image: ghcr.io/hyperledger-labs/explorer-db:latest
     container_name: explorerdb.mynetwork.com
     hostname: explorerdb.mynetwork.com
     # network_mode: "host"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ networks:
 services:
 
   explorerdb.mynetwork.com:
-    image: hyperledger/explorer-db:latest
+    image: ghcr.io/hyperledger-labs/explorer-db:latest
     container_name: explorerdb.mynetwork.com
     hostname: explorerdb.mynetwork.com
     environment:
@@ -31,7 +31,7 @@ services:
       - mynetwork.com
 
   explorer.mynetwork.com:
-    image: hyperledger/explorer:latest
+    image: ghcr.io/hyperledger-labs/explorer:latest
     container_name: explorer.mynetwork.com
     hostname: explorer.mynetwork.com
     environment:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:
Change the image location in docker-compose pointing to GHCR . Earlier the images were stored in docker-hub. From now on the images would be stored in GHCR. To suffice this requirement, need to update the docker-compose.

#### Which issue(s) this PR fixes: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #435 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NO
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
