### PR TITLE
Adding Boottime Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,73 @@ $ npm run build
 
 ## Run Hyperledger Explorer
 
+### Bootup Mode
+
+The Bootup Mode feature allows you to specify how many blocks should be loaded when starting the Hyperledger Explorer. You can choose from the below two modes:
+
+-   **ALL**: Load all available blocks.
+-   **CUSTOM**: Load a specific number of blocks as configured in the `config.json` file.
+
+To set the Bootup Mode, update the `app/platform/fabric/config.json` file in your project with the desired mode.
+
+-   **ALL**
+      ```json
+        {
+            "network-configs": {
+                "test-network": {
+                    "name": "Test Network",
+                    "profile": "./connection-profile/test-network.json",
+                    "enableAuthentication": false,
+                    "bootMode": "ALL",
+                    "noOfBlocks": 0
+                }
+            },
+            "license": "Apache-2.0"
+        }
+      ```
+**Note:** In ALL Mode, Please make sure that `noOfBlocks` paramater is set to `0`
+
+-   **CUSTOM**
+
+    The `noOfBlocks` parameter allows you to specify the number of blocks that the Hyperledger Explorer will use when booting up. If you are using custom mode and want to control the number of blocks, make sure to pass your desired value to the `noOfBlocks` parameter.
+
+      ```json
+        {
+            "network-configs": {
+                "test-network": {
+                    "name": "Test Network",
+                    "profile": "./connection-profile/test-network.json",
+                    "enableAuthentication": false,
+                    "bootMode": "CUSTOM",
+                    "noOfBlocks": 5
+                }
+            },
+            "license": "Apache-2.0"
+        }
+      ```
+
+**Note:** Setting `noOfBlocks` to `0` will load Hyperledger Explorer with the latest block.
+
+### Bootup Mode example for reference 
+
+Let's say your blockchain network consists of a total of 20 blocks, numbered from 1 to 20. You are interested in loading only the latest 5 blocks, which are blocks 20, 19, 18, 17, and 16.
+
+Here is an example of how you can configure Hyperledger Explorer to achieve this:
+  ```json
+        {
+            "network-configs": {
+                "test-network": {
+                    "name": "Test Network",
+                    "profile": "./connection-profile/test-network.json",
+                    "enableAuthentication": false,
+                    "bootMode": "CUSTOM",
+                    "noOfBlocks": 5
+                }
+            },
+            "license": "Apache-2.0"
+        }
+  ```
+
 ### Run Locally in the Same Location
 
 * Modify `app/explorerconfig.json` to update sync settings.

--- a/app/persistence/fabric/CRUDService.ts
+++ b/app/persistence/fabric/CRUDService.ts
@@ -546,6 +546,21 @@ export class CRUDService {
 	// Orderer BE-303
 
 	/**
+	 * Returns whether the block is available in the DB or not
+	 *
+	 * @param {*} blockHeight
+	 * @returns
+	 * @memberof CRUDService
+	 */
+	async isBlockAvailableInDB(channel_genesis_hash: string, blockHeight: number) {
+		const count: any = await this.sql.getRowsBySQlCase(
+			`SELECT COUNT(*) FROM blocks WHERE channel_genesis_hash= $1 AND blocknum = $2`,
+			[channel_genesis_hash, blockHeight]
+		);
+		return count.count > 0;
+	}
+
+	/**
 	 *
 	 * Returns the block by block number.
 	 *

--- a/app/platform/fabric/config.json
+++ b/app/platform/fabric/config.json
@@ -2,7 +2,9 @@
 	"network-configs": {
 		"test-network": {
 			"name": "Test Network",
-			"profile": "./connection-profile/test-network.json"
+			"profile": "./connection-profile/test-network.json",
+			"bootMode": "ALL",
+			"noOfBlocks": 0
 		}
 	},
 	"license": "Apache-2.0"

--- a/app/platform/fabric/utils/FabricConst.ts
+++ b/app/platform/fabric/utils/FabricConst.ts
@@ -18,3 +18,8 @@ export const fabric = {
 		NOTITY_TYPE_CLIENTERROR: '6'
 	}
 };
+
+export enum BootModes {
+	'ALL',
+	'CUSTOM'
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

Load only the blocks and transactions as per the configuration. Currently the configuration defines to archive or delete old data from the database. But at the bootstrap time, the Explorer tries to read every data from block 0. This can be configured to load only the data from certain point in time that is as expected by the Explorer's configuration.

_This will help in speeding up the bootstrap time of Explorer, the tool and the UI will be ready in shorter period._

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #393

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note
NO
```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
