### PR TITLE
feat: Allow explorer to be hosted in a subdirectory

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
 	"version": "2.0.0",
 	"private": true,
 	"license": "Apache-2.0",
+	"homepage": ".",
 	"dependencies": {
 		"@emotion/react": "^11.10.5",
 		"@emotion/styled": "^11.10.5",

--- a/client/src/state/redux/auth/operations.js
+++ b/client/src/state/redux/auth/operations.js
@@ -18,7 +18,7 @@ import actions from '../charts/actions';
 import Auth from '../../Auth';
 
 const login = ({ user, password }, networkObj) => dispatch =>
-	post('/auth/login', { user, password, network: networkObj })
+	post('auth/login', { user, password, network: networkObj })
 		.then(resp => {
 			Auth.authenticateUser(resp.token);
 			dispatch(errorAction(null));
@@ -33,7 +33,7 @@ const login = ({ user, password }, networkObj) => dispatch =>
 		});
 
 const network = () => dispatch =>
-	get('/auth/networklist', {})
+	get('auth/networklist', {})
 		.then(({ networkList }) => {
 			dispatch(networkAction({ networks: networkList }));
 		})
@@ -44,7 +44,7 @@ const network = () => dispatch =>
 		});
 
 const register = user => dispatch =>
-	post('/api/register', { ...user })
+	post('api/register', { ...user })
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -67,7 +67,7 @@ const register = user => dispatch =>
 		});
 
 const userlist = () => dispatch =>
-	get('/api/userlist')
+	get('api/userlist')
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -90,7 +90,7 @@ const userlist = () => dispatch =>
 		});
 
 const unregister = user => dispatch =>
-	post('/api/unregister', { ...user })
+	post('api/unregister', { ...user })
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -113,7 +113,7 @@ const unregister = user => dispatch =>
 		});
 
 const logout = () => dispatch =>
-	post('/auth/logout', {})
+	post('auth/logout', {})
 		.then(resp => {
 			console.log(resp);
 			Auth.deauthenticateUser();

--- a/client/src/state/redux/charts/operations.js
+++ b/client/src/state/redux/charts/operations.js
@@ -7,7 +7,7 @@ import { get } from '../../../services/request';
 
 /* istanbul ignore next */
 const blockPerHour = channelName => dispatch =>
-	get(`/api/blocksByHour/${channelName}/1`)
+	get(`api/blocksByHour/${channelName}/1`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -27,7 +27,7 @@ const blockPerHour = channelName => dispatch =>
 
 /* istanbul ignore next */
 const blockPerMin = channelName => dispatch =>
-	get(`/api/blocksByMinute/${channelName}/1`)
+	get(`api/blocksByMinute/${channelName}/1`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -47,7 +47,7 @@ const blockPerMin = channelName => dispatch =>
 
 /* istanbul ignore next */
 const changeChannel = channelName => dispatch =>
-	get(`/api/changeChannel/${channelName}`)
+	get(`api/changeChannel/${channelName}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -67,7 +67,7 @@ const changeChannel = channelName => dispatch =>
 
 /* istanbul ignore next */
 const channel = () => dispatch =>
-	get('/api/curChannel')
+	get('api/curChannel')
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -87,7 +87,7 @@ const channel = () => dispatch =>
 
 /* istanbul ignore next */
 const channelList = () => dispatch =>
-	get('/api/channels')
+	get('api/channels')
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -107,7 +107,7 @@ const channelList = () => dispatch =>
 
 /* istanbul ignore next */
 const dashStats = channelName => dispatch =>
-	get(`/api/status/${channelName}`)
+	get(`api/status/${channelName}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -127,7 +127,7 @@ const dashStats = channelName => dispatch =>
 
 /* istanbul ignore next */
 const blockActivity = channelName => dispatch =>
-	get(`/api/blockActivity/${channelName}`)
+	get(`api/blockActivity/${channelName}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -154,7 +154,7 @@ const notification = notificationObj => dispatch => {
 
 /* istanbul ignore next */
 const transactionByOrg = channelName => dispatch =>
-	get(`/api/txByOrg/${channelName}`)
+	get(`api/txByOrg/${channelName}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -174,7 +174,7 @@ const transactionByOrg = channelName => dispatch =>
 
 /* istanbul ignore next */
 const transactionPerHour = channelName => dispatch =>
-	get(`/api/txByHour/${channelName}/1`)
+	get(`api/txByHour/${channelName}/1`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -194,7 +194,7 @@ const transactionPerHour = channelName => dispatch =>
 
 /* istanbul ignore next */
 const transactionPerMin = channelName => dispatch =>
-	get(`/api/txByMinute/${channelName}/1`)
+	get(`api/txByMinute/${channelName}/1`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(

--- a/client/src/state/redux/tables/operations.js
+++ b/client/src/state/redux/tables/operations.js
@@ -7,7 +7,7 @@ import { get } from '../../../services/request';
 /* istanbul ignore next */
 const blockListSearch = (channel, query, pageParams) => dispatch =>
 	get(
-		`/api/blockAndTxList/${channel}/0?${query ? query : ''
+		`api/blockAndTxList/${channel}/0?${query ? query : ''
 		}&page=${pageParams?.page || 1}&size=${pageParams?.size || 10}`
 	)
 		.then(resp => {
@@ -30,7 +30,7 @@ const blockListSearch = (channel, query, pageParams) => dispatch =>
 
 /* istanbul ignore next */
 const chaincodeList = channel => dispatch =>
-	get(`/api/chaincode/${channel}`)
+	get(`api/chaincode/${channel}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -52,7 +52,7 @@ const chaincodeList = channel => dispatch =>
 
 /* istanbul ignore next */
 const channels = () => dispatch =>
-	get('/api/channels/info')
+	get('api/channels/info')
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -72,7 +72,7 @@ const channels = () => dispatch =>
 
 /* istanbul ignore next */
 const peerList = channel => dispatch =>
-	get(`/api/peersStatus/${channel}`)
+	get(`api/peersStatus/${channel}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -91,7 +91,7 @@ const peerList = channel => dispatch =>
 		});
 
 const txnList = (channel, query) => dispatch =>
-	get(`/api/fetchDataByTxnId/${channel}/${query}`)
+	get(`api/fetchDataByTxnId/${channel}/${query}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -111,7 +111,7 @@ const txnList = (channel, query) => dispatch =>
 		});
 
 const blockSearch = (channel, query) => dispatch =>
-	get(`/api/fetchDataByBlockNo/${channel}/${query}`)
+	get(`api/fetchDataByBlockNo/${channel}/${query}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -132,7 +132,7 @@ const blockSearch = (channel, query) => dispatch =>
 
 /* istanbul ignore next */
 const transaction = (channel, transactionId) => dispatch =>
-	get(`/api/transaction/${channel}/${transactionId}`)
+	get(`api/transaction/${channel}/${transactionId}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -151,7 +151,7 @@ const transaction = (channel, transactionId) => dispatch =>
 		});
 
 const transactionListSearch = (channel, query, pageParams) => dispatch =>
-	get(`/api/txList/${channel}/0/0?${query?query:''}&page=${pageParams?.page||1}&size=${pageParams?.size||10}`)
+	get(`api/txList/${channel}/0/0?${query?query:''}&page=${pageParams?.page||1}&size=${pageParams?.size||10}`)
 		.then(resp => {
 			let params={page:pageParams?.page||1,size:pageParams?.size ||10}
 			dispatch(actions.getTransactionListSearch({...resp,query,pageParams:params}));
@@ -162,7 +162,7 @@ const transactionListSearch = (channel, query, pageParams) => dispatch =>
 const blockRangeSearch = (channel, query1, query2) => dispatch =>
 		{
 			dispatch(actions.getLoaded(false));
-			get(`/api/fetchDataByBlockRange/${channel}/${query1}/${query2}`)
+			get(`api/fetchDataByBlockRange/${channel}/${query1}/${query2}`)
 			.then(resp => {
 				console.log('response-got', resp);
 				if (resp.status === 500) {
@@ -183,7 +183,7 @@ const blockRangeSearch = (channel, query1, query2) => dispatch =>
 	}
 /* istanbul ignore next */
 const transactionList = (channel,params) => dispatch =>
-	get(`/api/txList/${channel}/0/0/?page=${params.page}&size=${params.size}`)
+	get(`api/txList/${channel}/0/0/?page=${params.page}&size=${params.size}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -202,7 +202,7 @@ const transactionList = (channel,params) => dispatch =>
 		});
 
 const chaincodeMetaData = (channel,query) => dispatch =>
-	get(`/api/metadata/${channel}/${query}`)
+	get(`api/metadata/${channel}/${query}`)
 		.then(resp => {
 			if (resp.status === 500) {
 				dispatch(
@@ -219,13 +219,13 @@ const chaincodeMetaData = (channel,query) => dispatch =>
 		.catch(error => {
 			console.error(error);
 		});
-	
+
 export default {
 	chaincodeList,
 	channels,
 	peerList,
-	txnList, 
-	blockSearch, 
+	txnList,
+	blockSearch,
 	chaincodeMetaData,
 	transaction,
 	transactionList,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

Currently the Hyperledger explorer can only be hosted at the root of a domain name. With this change it's possible to also host it at a subdirectory of a domain for example: `https://example.com/your-fabric-explorer-instance`. 

In order to allow this i added the "homepage" property to the package.json as is described in the [create-react-app documentation](https://create-react-app.dev/docs/deployment/#building-for-relative-paths). By using "." for the homepage you it will always fetch the static files relative too where the explorer is being hosted, this way you don't need to change anything at build time. 

Next to that i also changed the location of the api operations to use relative urls as well. This works since a hash-based routing is currently being used.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
