### PR TITLE
fix: Catch error when _lifecycle chaincode is not running preventing Synchronizer to shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@
 
 Explorer is a simple, powerful, easy-to-use, well-maintained, open-source utility to browse activity on the underlying blockchain network. Users can configure and build Hyperledger Explorer on macOS and Ubuntu.
 
-**Update!** Explorer now can be used with [**Hyperledger Iroha**](https://github.com/hyperledger/iroha). For Iroha support, please switch to [iroha-integration](../../tree/iroha-integration) branch and read this [README](../../tree/iroha-integration/iroha) for instructions on how to use it.
-
 
 # Current Release
 

--- a/app/platform/fabric/gateway/FabricGateway.ts
+++ b/app/platform/fabric/gateway/FabricGateway.ts
@@ -342,16 +342,27 @@
 		 let resultJson = fabprotos.protos.ChaincodeQueryResponse.decode(result);
 		 if (resultJson.chaincodes.length <= 0) {
 			 resultJson = { chaincodes: [], toJSON: null };
-			 contract = network.getContract('_lifecycle');
-			 result = await contract.evaluateTransaction('QueryChaincodeDefinitions', '');
-			 const decodedReult = fabprotos.lifecycle.QueryChaincodeDefinitionsResult.decode(
-				 result
-			 );
-			 for (const cc of decodedReult.chaincode_definitions) {
-				 resultJson.chaincodes = concat(resultJson.chaincodes, {
-					 name: cc.name,
-					 version: cc.version
-				 });
+			 try {
+				 contract = network.getContract('_lifecycle');
+				 result = await contract.evaluateTransaction('QueryChaincodeDefinitions', '');
+					 const decodedReult = fabprotos.lifecycle.QueryChaincodeDefinitionsResult.decode(
+					 result
+				 );
+				 for (const cc of decodedReult.chaincode_definitions) {
+					 resultJson.chaincodes = concat(resultJson.chaincodes, {
+						 name: cc.name,
+						 version: cc.version
+					 });
+				 }
+			 } catch (error) {
+				 if (
+					 typeof error['message'] === 'string' &&
+					 error['message'].includes('is not running chaincode _lifecycle')
+				 ) {
+					 logger.debug('_lifecycle chaincode is not running');
+				 } else {
+					 throw error;
+				 }
 			 }
 		 }
 		 logger.debug('queryInstantiatedChaincodes', resultJson);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->


#### What this PR does / why we need it:

Right now when you set up an empty network that just contains a peer and an orderer and you install an explorer on it it will crash the Synchronizer because it cannot find any chaincodes. 

If it doesn't find any chaincodes it will fallback to the `_lifecycle` chaincode and if that is not installed it will crash because the peer will answer with `Peer XXXXX is not running chaincode _lifecycle`. If then later on blocks are being added or chaincode is installed it won't pick this up.

This is the error that it throws

```
2023-09-11T15:39:05.991Z - error: [SingleQueryHandler]: evaluate: message=Query failed. Errors: ["Error: Peer fab2p1-3041 is not running chaincode _lifecycle"], stack=FabricError: Query failed. Errors: ["Error: Peer fab2p1-3041 is not running chaincode │
│     at SingleQueryHandler.evaluate (/opt/explorer/node_modules/fabric-network/lib/impl/query/singlequeryhandler.js:66:23)                                                                                                                                    │
│     at processTicksAndRejections (internal/process/task_queues.js:97:5)                                                                                                                                                                                      │
│     at async Transaction.evaluate (/opt/explorer/node_modules/fabric-network/lib/transaction.js:319:25), name=FabricError                                                                                                                                    │
│ [2023-09-11T15:39:05.992] [ERROR] Sync - <<<<<<<<<<<<<<<<<<<<<<<<<< Synchronizer Error >>>>>>>>>>>>>>>>>>>>>                                                                                                                                                 │
│ [2023-09-11T15:39:05.992] [ERROR] Sync - Error [FabricError]: Query failed. Errors: ["Error: Peer fab2p1-3041 is not running chaincode _lifecycle"]                                                                                                          │
│     at SingleQueryHandler.evaluate (/opt/explorer/node_modules/fabric-network/lib/impl/query/singlequeryhandler.js:66:23)                                                                                                                                    │
│     at processTicksAndRejections (internal/process/task_queues.js:97:5)                                                                                                                                                                                      │
│     at async Transaction.evaluate (/opt/explorer/node_modules/fabric-network/lib/transaction.js:319:25)                                                                                                                                                      │
│ [2023-09-11T15:39:05.992] [INFO] Sync - <<<<<<<<<<<<<<<<<<<<<<<<<< Closing client processor >>>>>>>>>>>>>>>>>>>>> 
```

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
```release-note

```

#### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.


-->
```docs

```
