### PR TITLE
Update platformroutes.ts

### DIFF
--- a/app/rest/platformroutes.ts
+++ b/app/rest/platformroutes.ts
@@ -87,10 +87,10 @@ export async function platformroutes(
 	 * }
 	 * ]
 	 */
-	router.get('/peersStatus/:channel', (req, res) => {
-		const channelName = req.params.channel;
+	router.get('/peersStatus/:channel_genesis_hash', (req, res) => {
+		const channel_genesis_hash = req.params.channel_genesis_hash;
 		if (channelName) {
-			proxy.getPeersStatus(req.network, channelName).then((data: any) => {
+			proxy.getPeersStatus(req.network, channel_genesis_hash).then((data: any) => {
 				res.send({ status: 200, peers: data });
 			});
 		} else {


### PR DESCRIPTION
#### What this PR does / why we need it:
`/api/peersStatus/:channel` endpoint does not work if `:channel` is channel name (e.g. mychannel) because `proxy.getPeersStatus()` expects `channel_genesis_hash` as parameter. I have changed the code to reflect such differences.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
```release-note

```

#### Additional documentation, usage docs, etc.:

```docs

```
