### PR TITLE
add the channel name to the example

### DIFF
--- a/examples/net1/connection-profile/test-network.json
+++ b/examples/net1/connection-profile/test-network.json
@@ -9,6 +9,7 @@
 		},
 		"enableAuthentication": true,
 		"organization": "Org1MSP",
+		"channel": "mychannel",
 		"connection": {
 			"timeout": {
 				"peer": {


### PR DESCRIPTION
#### What this PR does / why we need it:

In the example, the explorer crashes after a minute or so, because of a field called "name" is missing. It seems that it's because of the "channel" field that was missing from the connection profile. This field is present in the examples [README.md](https://github.com/hyperledger-labs/blockchain-explorer/tree/main/examples/net1).

#### Which issue(s) this PR fixes:

Fixes https://github.com/hyperledger-labs/blockchain-explorer/issues/478

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

No.

#### Additional documentation, usage docs, etc.:

